### PR TITLE
Fixes dmtxDecodeMatrixRegion returning a freed pointer

### DIFF
--- a/dmtx.h
+++ b/dmtx.h
@@ -544,7 +544,7 @@ extern int dmtxDecodeGetProp(DmtxDecode *dec, int prop);
 extern /*@exposed@*/ unsigned char *dmtxDecodeGetCache(DmtxDecode *dec, int x, int y);
 extern DmtxPassFail dmtxDecodeGetPixelValue(DmtxDecode *dec, int x, int y, int channel, /*@out@*/ int *value);
 extern DmtxMessage *dmtxDecodeMatrixRegion(DmtxDecode *dec, DmtxRegion *reg, int fix);
-extern void dmtxDecodePopulatedArray(int sizeIdx, DmtxMessage *msg, int fix);
+extern DmtxMessage *dmtxDecodePopulatedArray(int sizeIdx, DmtxMessage *msg, int fix);
 extern DmtxMessage *dmtxDecodeMosaicRegion(DmtxDecode *dec, DmtxRegion *reg, int fix);
 extern unsigned char *dmtxDecodeCreateDiagnostic(DmtxDecode *dec, /*@out@*/ int *totalBytes, /*@out@*/ int *headerBytes, int style);
 

--- a/dmtxdecode.c
+++ b/dmtxdecode.c
@@ -356,8 +356,7 @@ dmtxDecodeMatrixRegion(DmtxDecode *dec, DmtxRegion *reg, int fix)
 
    CacheFillQuad(dec, pxTopLeft, pxTopRight, pxBottomRight, pxBottomLeft);
 
-   dmtxDecodePopulatedArray(reg->sizeIdx, msg, fix);
-   return msg;
+   return dmtxDecodePopulatedArray(reg->sizeIdx, msg, fix);
 }
 
 /**
@@ -365,9 +364,12 @@ dmtxDecodeMatrixRegion(DmtxDecode *dec, DmtxRegion *reg, int fix)
  * \param  sizeIdx
  * \param  msg
  * \param  fix
- * \return Decoded message
+ * \return Decoded message (msg pointer) or NULL in case of failure.
+ * \note You should reaffect msg with the result of this call
+ *       since a NULL result means msg gets freed and should not be used anymore.
+ *       ex: msg = dmtxDecodePopulatedArray(sizeidx, msg, fix);
  */
-void
+DmtxMessage *
 dmtxDecodePopulatedArray(int sizeIdx, DmtxMessage *msg, int fix)
 {
    /*
@@ -394,12 +396,12 @@ dmtxDecodePopulatedArray(int sizeIdx, DmtxMessage *msg, int fix)
    if(RsDecode(msg->code, sizeIdx, fix) == DmtxFail){
       dmtxMessageDestroy(&msg);
       msg = NULL;
-      return;
+      return NULL;
    }
 
    DecodeDataStream(msg, sizeIdx, NULL);
 
-   return;
+   return msg;
 }
 
 /**


### PR DESCRIPTION
Call to dmtxDecodePopulatedArray can free msg argument,
which should no more be used when freed.

Unfortunately dmtxDecodePopulatedArray returned no hints
whereas it freed this pointer or not. This commit fixes
dmtxDecodePopulatedArray return type so that it informs
when it has freed its msg argument.

This commit fixes a regression inserted by e4233cac.