### PR TITLE
Add support for GS-1 encoding via the FCN1 character

### DIFF
--- a/dmtx.h
+++ b/dmtx.h
@@ -163,6 +163,7 @@ typedef enum {
    DmtxPropSizeRequest,
    DmtxPropMarginSize,
    DmtxPropModuleSize,
+   DmtxPropFnc1,
    /* Decoding properties */
    DmtxPropEdgeMin           = 200,
    DmtxPropEdgeMax,
@@ -277,6 +278,7 @@ struct DmtxEncodeStream_struct
    int outputChainWordCount;  /* Count of output words pushed within current scheme chain */
    char *reason;              /* Reason for status */
    int sizeIdx;               /* Symbol size of completed stream */
+   int fnc1;                  /* Character to represent FNC1, or DmtxUndefined */
    DmtxStatus status;
    DmtxByteList *input;
    DmtxByteList *output;
@@ -394,6 +396,7 @@ typedef struct DmtxMessage_struct {
    size_t          outputSize;    /* Size of buffer used to hold decoded data */
    int             outputIdx;     /* Internal index used to store output progress */
    int             padCount;
+   int             fnc1;          /* Character to represent FNC1, or DmtxUndefined */
    unsigned char  *array;         /* Pointer to internal representation of Data Matrix modules */
    unsigned char  *code;          /* Pointer to internal storage of code words (data and error) */
    unsigned char  *output;        /* Pointer to internal storage of decoded output */
@@ -445,6 +448,7 @@ typedef struct DmtxDecode_struct {
    int             edgeMin;
    int             edgeMax;
    int             scanGap;
+   int             fnc1;
    double          squareDevn;
    int             sizeIdxExpected;
    int             edgeThresh;
@@ -476,6 +480,7 @@ typedef struct DmtxEncode_struct {
    int             pixelPacking;
    int             imageFlip;
    int             rowPadBytes;
+   int             fnc1;
    DmtxMessage    *message;
    DmtxImage      *image;
    DmtxRegion      region;

--- a/dmtxdecode.c
+++ b/dmtxdecode.c
@@ -37,6 +37,8 @@ dmtxDecodeCreate(DmtxImage *img, int scale)
    width = dmtxImageGetProp(img, DmtxPropWidth) / scale;
    height = dmtxImageGetProp(img, DmtxPropHeight) / scale;
 
+   dec->fnc1 = DmtxUndefined;
+
    dec->edgeMin = DmtxUndefined;
    dec->edgeMax = DmtxUndefined;
    dec->scanGap = 1;
@@ -103,6 +105,9 @@ dmtxDecodeSetProp(DmtxDecode *dec, int prop, int value)
       case DmtxPropScanGap:
          dec->scanGap = value; /* XXX Should this be scaled? */
          break;
+      case DmtxPropFnc1:
+         dec->fnc1 = value;
+         break;
       case DmtxPropSquareDevn:
          dec->squareDevn = cos(value * (M_PI/180.0));
          break;
@@ -160,6 +165,8 @@ dmtxDecodeGetProp(DmtxDecode *dec, int prop)
          return dec->edgeMax;
       case DmtxPropScanGap:
          return dec->scanGap;
+      case DmtxPropFnc1:
+         return dec->fnc1;
       case DmtxPropSquareDevn:
          return (int)(acos(dec->squareDevn) * 180.0/M_PI);
       case DmtxPropSymbolSize:
@@ -336,6 +343,8 @@ dmtxDecodeMatrixRegion(DmtxDecode *dec, DmtxRegion *reg, int fix)
       dmtxMessageDestroy(&msg);
       return NULL;
    }
+
+   msg->fnc1 = dec->fnc1;
 
    topLeft.X = bottomLeft.X = topLeft.Y = topRight.Y = -0.1;
    topRight.X = bottomRight.X = bottomLeft.Y = bottomRight.Y = 1.1;

--- a/dmtxdecodescheme.c
+++ b/dmtxdecodescheme.c
@@ -230,6 +230,11 @@ DecodeSchemeAscii(DmtxMessage *msg, unsigned char *ptr, unsigned char *dataEnd)
          PushOutputWord(msg, digits/10 + '0');
          PushOutputWord(msg, digits - (digits/10)*10 + '0');
       }
+      else if(codeword == DmtxValueFNC1) {
+         if(msg->fnc1 != DmtxUndefined) {
+             PushOutputWord(msg, msg->fnc1);
+         }
+      }
    }
 
    return ptr;
@@ -303,7 +308,9 @@ DecodeSchemeC40Text(DmtxMessage *msg, unsigned char *ptr, unsigned char *dataEnd
                PushOutputC40TextWord(msg, &state, c40Values[i] + 69); /* ASCII 91 - 95 */
             }
             else if(c40Values[i] == 27) {
-               PushOutputC40TextWord(msg, &state, 0x1d); /* FNC1 -- XXX depends on position? */
+               if(msg->fnc1 != DmtxUndefined) {
+                   PushOutputC40TextWord(msg, &state, msg->fnc1);
+               }
             }
             else if(c40Values[i] == 30) {
                state.upperShift = DmtxTrue;

--- a/dmtxencode.c
+++ b/dmtxencode.c
@@ -38,6 +38,8 @@ dmtxEncodeCreate(void)
    enc->imageFlip = DmtxFlipNone;
    enc->rowPadBytes = 0;
 
+   enc->fnc1 = DmtxUndefined;
+
    /* Initialize background color to white */
 /* enc.region.gradient.ray.p.R = 255.0;
    enc.region.gradient.ray.p.G = 255.0;
@@ -100,6 +102,9 @@ dmtxEncodeSetProp(DmtxEncode *enc, int prop, int value)
             return DmtxFail;
          enc->sizeIdxRequest = value;
          break;
+      case DmtxPropFnc1:
+         enc->fnc1 = value;
+         break;
 
       /* Presentation details */
       case DmtxPropMarginSize:
@@ -141,6 +146,8 @@ dmtxEncodeGetProp(DmtxEncode *enc, int prop)
          return enc->moduleSize;
       case DmtxPropScheme:
          return enc->scheme;
+      case DmtxPropFnc1:
+         return enc->fnc1;
       default:
          break;
    }
@@ -172,7 +179,7 @@ dmtxEncodeDataMatrix(DmtxEncode *enc, int inputSize, unsigned char *inputString)
    /* Future: EncodeDataCodewords(&stream) ... */
 
    /* Encode input string into data codewords */
-   sizeIdx = EncodeDataCodewords(&input, &output, enc->sizeIdxRequest, enc->scheme);
+   sizeIdx = EncodeDataCodewords(&input, &output, enc->sizeIdxRequest, enc->scheme, enc->fnc1);
    if(sizeIdx == DmtxUndefined || output.length <= 0)
       return DmtxFail;
 
@@ -381,7 +388,7 @@ dmtxEncodeDataMosaic(DmtxEncode *enc, int inputSize, unsigned char *inputString)
  *         goes to EncodeSingle... too
  */
 static int
-EncodeDataCodewords(DmtxByteList *input, DmtxByteList *output, int sizeIdxRequest, DmtxScheme scheme)
+EncodeDataCodewords(DmtxByteList *input, DmtxByteList *output, int sizeIdxRequest, DmtxScheme scheme, int fnc1)
 {
    int sizeIdx;
 
@@ -389,13 +396,13 @@ EncodeDataCodewords(DmtxByteList *input, DmtxByteList *output, int sizeIdxReques
    switch(scheme)
    {
       case DmtxSchemeAutoBest:
-         sizeIdx = EncodeOptimizeBest(input, output, sizeIdxRequest);
+         sizeIdx = EncodeOptimizeBest(input, output, sizeIdxRequest, fnc1);
          break;
       case DmtxSchemeAutoFast:
          sizeIdx = DmtxUndefined; /* EncodeAutoFast(input, output, sizeIdxRequest, passFail); */
          break;
       default:
-         sizeIdx = EncodeSingleScheme(input, output, sizeIdxRequest, scheme);
+         sizeIdx = EncodeSingleScheme(input, output, sizeIdxRequest, scheme, fnc1);
          break;
    }
 

--- a/dmtxencodeascii.c
+++ b/dmtxencodeascii.c
@@ -41,7 +41,15 @@ EncodeNextChunkAscii(DmtxEncodeStream *stream, int option)
             StreamInputHasNext(stream))
       {
          v1 = StreamInputPeekNext(stream); CHKERR;
-         compactDigits = (ISDIGIT(v0) && ISDIGIT(v1)) ? DmtxTrue : DmtxFalse;
+
+         /* Check for FNC1 character */
+         if(stream->fnc1 != DmtxUndefined && (int)v1 == stream->fnc1)
+         {
+            v1 = 0;
+            compactDigits = DmtxFalse;
+         }
+         else
+            compactDigits = (ISDIGIT(v0) && ISDIGIT(v1)) ? DmtxTrue : DmtxFalse;
       }
       else /* option == DmtxEncodeFull */
       {
@@ -63,7 +71,12 @@ EncodeNextChunkAscii(DmtxEncodeStream *stream, int option)
       else
       {
          /* Encode single ASCII value */
-         if(v0 < 128)
+         if(stream->fnc1 != DmtxUndefined && (int)v0 == stream->fnc1)
+         {
+            /* FNC1 */
+            AppendValueAscii(stream, DmtxValueFNC1); CHKERR;
+         }
+         else if(v0 < 128)
          {
             /* Regular ASCII */
             AppendValueAscii(stream, v0 + 1); CHKERR;

--- a/dmtxencodebase256.c
+++ b/dmtxencodebase256.c
@@ -25,6 +25,16 @@ EncodeNextChunkBase256(DmtxEncodeStream *stream)
 
    if(StreamInputHasNext(stream))
    {
+      /* Check for FNC1 character, which needs to be sent in ASCII */
+      value = StreamInputPeekNext(stream); CHKERR;
+      if(stream->fnc1 != DmtxUndefined && (int)value == stream->fnc1) {
+         EncodeChangeScheme(stream, DmtxSchemeAscii, DmtxUnlatchExplicit);
+
+         StreamInputAdvanceNext(stream); CHKERR;
+         AppendValueAscii(stream, DmtxValueFNC1); CHKERR;
+         return;
+      }
+
       value = StreamInputAdvanceNext(stream); CHKERR;
       AppendValueBase256(stream, value); CHKERR;
    }

--- a/dmtxencodeedifact.c
+++ b/dmtxencodeedifact.c
@@ -25,6 +25,16 @@ EncodeNextChunkEdifact(DmtxEncodeStream *stream)
 
    if(StreamInputHasNext(stream))
    {
+      /* Check for FNC1 character, which needs to be sent in ASCII */
+      value = StreamInputPeekNext(stream); CHKERR;
+      if(stream->fnc1 != DmtxUndefined && (int)value == stream->fnc1) {
+         EncodeChangeScheme(stream, DmtxSchemeAscii, DmtxUnlatchExplicit); CHKERR;
+
+         StreamInputAdvanceNext(stream); CHKERR;
+         AppendValueAscii(stream, DmtxValueFNC1); CHKERR;
+         return;
+      }
+
       value = StreamInputAdvanceNext(stream); CHKERR;
       AppendValueEdifact(stream, value); CHKERR;
    }

--- a/dmtxencodescheme.c
+++ b/dmtxencodescheme.c
@@ -85,11 +85,19 @@
  *
  */
 static int
-EncodeSingleScheme(DmtxByteList *input, DmtxByteList *output, int sizeIdxRequest, DmtxScheme scheme)
+EncodeSingleScheme(DmtxByteList *input, DmtxByteList *output, int sizeIdxRequest, DmtxScheme scheme, int fnc1)
 {
    DmtxEncodeStream stream;
 
    stream = StreamInit(input, output);
+   stream.fnc1 = fnc1;
+
+   /* 1st FNC1 special case, encode before scheme switch */
+   if (fnc1 != DmtxUndefined && (int)(input->b[0]) == fnc1)
+   {
+      StreamInputAdvanceNext(&stream);
+      AppendValueAscii(&stream, DmtxValueFNC1);
+   }
 
    /* Continue encoding until complete */
    while(stream.status == DmtxStatusEncoding)

--- a/dmtxencodestream.c
+++ b/dmtxencodestream.c
@@ -54,6 +54,7 @@ StreamCopy(DmtxEncodeStream *dst, DmtxEncodeStream *src)
    dst->sizeIdx = src->sizeIdx;
    dst->status = src->status;
    dst->input = src->input;
+   dst->fnc1 = src->fnc1;
 
    dmtxByteListCopy(dst->output, src->output, &passFail);
 }

--- a/dmtxstatic.h
+++ b/dmtxstatic.h
@@ -170,7 +170,7 @@ static unsigned char *DecodeSchemeBase256(DmtxMessage *msg, unsigned char *ptr, 
 
 /* dmtxencode.c */
 static void PrintPattern(DmtxEncode *encode);
-static int EncodeDataCodewords(DmtxByteList *input, DmtxByteList *output, int sizeIdxRequest, DmtxScheme scheme);
+static int EncodeDataCodewords(DmtxByteList *input, DmtxByteList *output, int sizeIdxRequest, DmtxScheme scheme, int fnc1);
 
 /* dmtxplacemod.c */
 static int ModulePlacementEcc200(unsigned char *modules, unsigned char *codewords, int sizeIdx, int moduleOnColor);
@@ -218,13 +218,13 @@ static DmtxByte StreamInputAdvanceNext(DmtxEncodeStream *stream);
 static void StreamInputAdvancePrev(DmtxEncodeStream *stream);
 
 /* dmtxencodescheme.c */
-static int EncodeSingleScheme(DmtxByteList *input, DmtxByteList *output, int sizeIdxRequest, DmtxScheme scheme);
+static int EncodeSingleScheme(DmtxByteList *input, DmtxByteList *output, int sizeIdxRequest, DmtxScheme scheme, int fnc1);
 static void EncodeNextChunk(DmtxEncodeStream *stream, int scheme, int subScheme, int sizeIdxRequest);
 static void EncodeChangeScheme(DmtxEncodeStream *stream, DmtxScheme targetScheme, int unlatchType);
 static int GetRemainingSymbolCapacity(int outputLength, int sizeIdx);
 
 /* dmtxencodeoptimize.c */
-static int EncodeOptimizeBest(DmtxByteList *input, DmtxByteList *output, int sizeIdxRequest);
+static int EncodeOptimizeBest(DmtxByteList *input, DmtxByteList *output, int sizeIdxRequest, int fnc1);
 static void StreamAdvanceFromBest(DmtxEncodeStream *streamNext,
       DmtxEncodeStream *streamList, int targeteState, int sizeIdxRequest);
 static void AdvanceAsciiCompact(DmtxEncodeStream *streamNext, DmtxEncodeStream *streamList,
@@ -252,7 +252,7 @@ static void CompleteIfDoneCTX(DmtxEncodeStream *stream, int sizeIdxRequest);
 static void CompletePartialC40Text(DmtxEncodeStream *stream, DmtxByteList *valueList, int sizeIdxRequest);
 static void CompletePartialX12(DmtxEncodeStream *stream, DmtxByteList *valueList, int sizeIdxRequest);
 static DmtxBoolean PartialX12ChunkRemains(DmtxEncodeStream *stream);
-static void PushCTXValues(DmtxByteList *valueList, DmtxByte inputValue, int targetScheme, DmtxPassFail *passFail);
+static void PushCTXValues(DmtxByteList *valueList, DmtxByte inputValue, int targetScheme, DmtxPassFail *passFail, int fnc1);
 static DmtxBoolean IsCTX(int scheme);
 static void ShiftValueListBy3(DmtxByteList *list, DmtxPassFail *passFail);
 


### PR DESCRIPTION
This patch adds the ability to encode GS-1 barcodes using the FNC1
character, which is defined by the new property 'DmtxPropFnc1' and
defaulted to 'DmtxUndefined'. Once set, the specified character
within the text of the barcode will be replaced with FNC1.

GS-1 encoding is valid for all barcode encodings, however FNC1 is
only valid for ASCII and C40/Text. Code will automatically escape to
ASCII where needed and is transparent for user.

An additional patch for dmtxutils is provided, using the command line
parameter '-G xx' allows user to specify the character they wish to
use/replace for FNC1.

Example use - '+' will be replaced FNC1:
$ echo -n '+0010030378123456789017130700103033262+3000017' | dmtxwrite -o test.png -G 43

and decoding replacing FNC1 with '*' (for validation):
$ dmtxread test.png -G 42
*0010030378123456789017130700103033262*3000017

Note: FNC1 is implied at the end of fixed length AI's, so is only
required to mark end of variable length AI's.