### PR TITLE
Bug 9: Prevent edifact barcode encoding '31' from user input

### DIFF
--- a/dmtxencodeedifact.c
+++ b/dmtxencodeedifact.c
@@ -28,7 +28,12 @@ EncodeNextChunkEdifact(DmtxEncodeStream *stream)
       /* Check for FNC1 character, which needs to be sent in ASCII */
       value = StreamInputPeekNext(stream); CHKERR;
 
-      if((value < 32 || value > 94) || (stream->fnc1 != DmtxUndefined && (int)value == stream->fnc1)) {
+      if((value < 32 || value > 94)) {
+         StreamMarkInvalid(stream, DmtxChannelUnsupportedChar);
+         return;
+      }
+
+      if (stream->fnc1 != DmtxUndefined && (int)value == stream->fnc1) {
          EncodeChangeScheme(stream, DmtxSchemeAscii, DmtxUnlatchExplicit); CHKERR;
 
          StreamInputAdvanceNext(stream); CHKERR;


### PR DESCRIPTION
Probably want to work out how to automatically escape to a workable
encoding, but need to know whether user has specifically requested
edifcat - this is a larger disuccusion for future.

```
$ echo -en 'OH\037CRAP' | dmtxwrite -o test.png -e e -G 43
dmtxwrite: Unable to encode message (possibly too large for requested size)

$ echo -en 'OH CRAP' | dmtxwrite -o test.png -e e -G 43
$ echo -en 'OH+CRAP' | dmtxwrite -o test.png -e e -G 43
$ dmtxread test.png -G 42
OH*CRAP
```