### PR TITLE
handle errors when decoding Base256 scheme

### DIFF
--- a/dmtxdecode.c
+++ b/dmtxdecode.c
@@ -408,7 +408,11 @@ dmtxDecodePopulatedArray(int sizeIdx, DmtxMessage *msg, int fix)
       return NULL;
    }
 
-   DecodeDataStream(msg, sizeIdx, NULL);
+   if(DecodeDataStream(msg, sizeIdx, NULL) == DmtxFail) {
+      dmtxMessageDestroy(&msg);
+      msg = NULL;
+      return NULL;
+   }
 
    return msg;
 }

--- a/dmtxdecodescheme.c
+++ b/dmtxdecodescheme.c
@@ -21,7 +21,7 @@
  * \param  outputStart
  * \return void
  */
-extern void
+extern DmtxPassFail
 DecodeDataStream(DmtxMessage *msg, int sizeIdx, unsigned char *outputStart)
 {
    //fprintf(stdout, "libdmtx::DecodeDataStream()\n");
@@ -76,11 +76,16 @@ DecodeDataStream(DmtxMessage *msg, int sizeIdx, unsigned char *outputStart)
             /* error */
             break;
       }
+
+      if(ptr == NULL)
+         return DmtxFail;
    }
 
    /* Print macro trailer if required */
    if(macro == DmtxTrue)
       PushOutputMacroTrailer(msg);
+
+   return DmtxPass;
 }
 
 /**
@@ -488,7 +493,8 @@ DecodeSchemeEdifact(DmtxMessage *msg, unsigned char *ptr, unsigned char *dataEnd
  * \param  msg
  * \param  ptr
  * \param  dataEnd
- * \return Pointer to next undecoded codeword
+ * \return Pointer to next undecoded codeword,
+ *         NULL if an error was detected in the stream
  */
 static unsigned char *
 DecodeSchemeBase256(DmtxMessage *msg, unsigned char *ptr, unsigned char *dataEnd)
@@ -515,7 +521,7 @@ DecodeSchemeBase256(DmtxMessage *msg, unsigned char *ptr, unsigned char *dataEnd
    }
 
    if(ptrEnd > dataEnd)
-      exit(40); /* XXX needs cleaner error handling */
+      return NULL;
 
    while(ptr < ptrEnd)
       PushOutputWord(msg, UnRandomize255State(*(ptr++), idx++));

--- a/dmtxstatic.h
+++ b/dmtxstatic.h
@@ -157,7 +157,7 @@ static void TallyModuleJumps(DmtxDecode *dec, DmtxRegion *reg, int tally[][24], 
 static DmtxPassFail PopulateArrayFromMatrix(DmtxDecode *dec, DmtxRegion *reg, DmtxMessage *msg);
 
 /* dmtxdecodescheme.c */
-static void DecodeDataStream(DmtxMessage *msg, int sizeIdx, unsigned char *outputStart);
+static DmtxPassFail DecodeDataStream(DmtxMessage *msg, int sizeIdx, unsigned char *outputStart);
 static int GetEncodationScheme(unsigned char cw);
 static void PushOutputWord(DmtxMessage *msg, int value);
 static void PushOutputC40TextWord(DmtxMessage *msg, C40TextState *state, int value);


### PR DESCRIPTION
Previously the library would cause the process to exit with code 40,
now we return a null pointer and plumb the error condition through
all call sites until we hit the API.

This changes the signature of 'DecodeDataStream', as it now
needs to signal an error condition in its return value.

Fixes #16.