### PR TITLE
CMake and CTest support for libdmtx.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.12)
+project(DMTX VERSION 0.7.5 LANGUAGES C)
+
+
+add_library(dmtx dmtx.c)
+target_link_libraries(dmtx -lm)
+
+#------------------------------------------------------------------------------#
+enable_testing()
+add_executable(simple
+  test/simple_test/simple_test.c)
+target_link_libraries(simple PRIVATE dmtx)
+add_test(NAME simpleTest COMMAND simple)
+
+#------------------------------------------------------------------------------#
+# this test doesn't work yet (nothing wrong with the code - something wrong with my script)
+# add_executable(unit
+#   test/unit_test/unit_test.c)
+# target_link_libraries(unit PRIVATE dmtx)
+# add_test(NAME unitTest COMMAND unit)
+

--- a/test/simple_test/simple_test.c
+++ b/test/simple_test/simple_test.c
@@ -19,7 +19,7 @@
 #include <string.h>
 #include <assert.h>
 #include <math.h>
-#include <dmtx.h>
+#include "../../dmtx.h"
 
 int
 main(int argc, char *argv[])


### PR DESCRIPTION
Hi - I know that your project didn't use CMake, but if you would like to have CMake and CTest support, I have added the necessary files, and tweaked one of your unit tests so that it could be run automatically.