### PR TITLE
Add validity checks in DecodeSchemeAscii()

### DIFF
--- a/dmtxdecodescheme.c
+++ b/dmtxdecodescheme.c
@@ -136,6 +136,16 @@ PushOutputWord(DmtxMessage *msg, int value)
 }
 
 /**
+*
+*
+*/
+static DmtxBoolean
+ValidOutputWord(int value)
+{
+   return (value >= 0 && value < 256) ? DmtxTrue : DmtxFalse;
+}
+
+/**
  *
  *
  */
@@ -196,12 +206,13 @@ PushOutputMacroTrailer(DmtxMessage *msg)
  * \param  ptr
  * \param  dataEnd
  * \return Pointer to next undecoded codeword
+ *         NULL if an error was detected in the stream
  */
 static unsigned char *
 DecodeSchemeAscii(DmtxMessage *msg, unsigned char *ptr, unsigned char *dataEnd)
 {
    int upperShift;
-   int codeword, digits;
+   int codeword, digits, pushword;
 
    upperShift = DmtxFalse;
 
@@ -215,7 +226,10 @@ DecodeSchemeAscii(DmtxMessage *msg, unsigned char *ptr, unsigned char *dataEnd)
          ptr++;
 
       if(upperShift == DmtxTrue) {
-         PushOutputWord(msg, codeword + 127);
+         pushword = codeword + 127;
+         if (ValidOutputWord(pushword) != DmtxTrue)
+            return NULL;
+         PushOutputWord(msg, pushword);
          upperShift = DmtxFalse;
       }
       else if(codeword == DmtxValueAsciiUpperShift) {
@@ -240,7 +254,10 @@ DecodeSchemeAscii(DmtxMessage *msg, unsigned char *ptr, unsigned char *dataEnd)
       }
       else if(codeword == DmtxValueFNC1) {
          if(msg->fnc1 != DmtxUndefined) {
-             PushOutputWord(msg, msg->fnc1);
+             pushword = msg->fnc1;
+             if (ValidOutputWord(pushword) != DmtxTrue)
+                return NULL;
+             PushOutputWord(msg, pushword);
          }
       }
    }

--- a/dmtxdecodescheme.c
+++ b/dmtxdecodescheme.c
@@ -211,14 +211,10 @@ PushOutputMacroTrailer(DmtxMessage *msg)
 static unsigned char *
 DecodeSchemeAscii(DmtxMessage *msg, unsigned char *ptr, unsigned char *dataEnd)
 {
-   int upperShift;
-   int codeword, digits, pushword;
-
-   upperShift = DmtxFalse;
+   int upperShift = DmtxFalse;
 
    while(ptr < dataEnd) {
-
-      codeword = (int)(*ptr);
+      int codeword = (int)(*ptr);
 
       if(GetEncodationScheme(*ptr) != DmtxSchemeAscii)
          return ptr;
@@ -226,7 +222,7 @@ DecodeSchemeAscii(DmtxMessage *msg, unsigned char *ptr, unsigned char *dataEnd)
          ptr++;
 
       if(upperShift == DmtxTrue) {
-         pushword = codeword + 127;
+         int pushword = codeword + 127;
          if (ValidOutputWord(pushword) != DmtxTrue)
             return NULL;
          PushOutputWord(msg, pushword);
@@ -248,13 +244,13 @@ DecodeSchemeAscii(DmtxMessage *msg, unsigned char *ptr, unsigned char *dataEnd)
          PushOutputWord(msg, codeword - 1);
       }
       else if(codeword <= 229) {
-         digits = codeword - 130;
+         int digits = codeword - 130;
          PushOutputWord(msg, digits/10 + '0');
          PushOutputWord(msg, digits - (digits/10)*10 + '0');
       }
       else if(codeword == DmtxValueFNC1) {
          if(msg->fnc1 != DmtxUndefined) {
-             pushword = msg->fnc1;
+             int pushword = msg->fnc1;
              if (ValidOutputWord(pushword) != DmtxTrue)
                 return NULL;
              PushOutputWord(msg, pushword);


### PR DESCRIPTION
This helps the function to return errors without using the assert in PushOutputWord()

I was wondering if we need to return error also on some other cases in DecodeSchemeAscii() ?
   - if the encodation scheme is not ASCII
   - if(codeword == 0 || codeword >= 242)

Currently those cases just return what we have read so far.
