### PR TITLE
Implement RsFindErrorLocatorPoly fix from shm0nya

### DIFF
--- a/dmtxreedsol.c
+++ b/dmtxreedsol.c
@@ -369,7 +369,8 @@ RsFindErrorLocatorPoly(DmtxByteList *elpOut, const DmtxByteList *syn, int errorW
 
          /* Calculate error location polynomial elp[i] (set 1st term) */
          for(lambda = elp[m].length - 1, j = 0; j <= lambda; j++)
-            elp[iNext].b[j+i-m] = antilog301[(NN - log301[dis.b[m]] +
+            elp[iNext].b[j+i-m] = (elp[i - 1].b[j] == 0) ? 0 :
+                  antilog301[(NN - log301[dis.b[m]] +
                   log301[dis.b[i]] + log301[elp[m].b[j]]) % NN];
 
          /* Calculate error location polynomial elp[i] (add 2nd term) */


### PR DESCRIPTION
I will not pretend to understand the math going on in this function or the fix. I have implemented the code change that @shm0nya suggested in https://github.com/dmtx/libdmtx/issues/30#issuecomment-580178216

Prior to this fix, I was seeing a large number of message decode failures in the 0.7.4 / 0.7.5 / master version of the library. I was able to decode those datamatrix code images prior to the Reed-Solomon refactor using release 0.7.0. I suspect 0.7.2 should work as well. One of the images I have been working with is attached.

![insertScanBad_crop](https://user-images.githubusercontent.com/67076388/84957096-1f168380-b0c0-11ea-8109-271aa6fdb74e.png)

 