### PR TITLE
Replace _VISUALC_ with MS predefined macros

### DIFF
--- a/dmtxdecode.c
+++ b/dmtxdecode.c
@@ -520,7 +520,7 @@ dmtxDecodeCreateDiagnostic(DmtxDecode *dec, int *totalBytes, int *headerBytes, i
    if(pnm == NULL)
       return NULL;
 
-#ifdef _VISUALC_
+#if defined(_MSC_VER) && (_MSC_VER < 1700)
    count = sprintf_s((char *)pnm, *headerBytes + 1, "P6\n%d %d\n255\n", width, height);
 #else
    count = snprintf((char *)pnm, *headerBytes + 1, "P6\n%d %d\n255\n", width, height);


### PR DESCRIPTION
According to [wikidot](http://libdmtx.wikidot.com/libdmtx-on-windows-using-visual-studio) the preprocessor definition `_VISUALC_` has to be defined in order to compile with Visual Studio.

This is done because older VS versions don't provide snprintf.
I didn't check with older versions, but this is true for VS2010 but not for VS2015 and above. I couldn't check VS2012/13 though.
Since MS provides [predefined macros](https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros) they can be used to distinguish between the cases.

To really stay backward compatible with some cases i don't know of, maybe VS versions < 6.0, the check could be altered to
`#if defined(_VISUALC_) || defined(_MSC_VER) && (_MSC_VER < 1700)`