### PR TITLE
Better test for MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ else()
 endif()
 
 # Compiler specific settings
-if(CMAKE_C_COMPILER_ID STREQUAL "MSVC")
+if (MSVC)
   set_target_properties(dmtx PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
 else()
   set_target_properties(dmtx PROPERTIES


### PR DESCRIPTION
I'm not an expert in CMake, but it seems the right way to test for MSVC is `if (MSVC)`.

without this patch, if I build a dll version no symbol is exported and no .lib file is created.